### PR TITLE
fix: kde versioning until "non-gear versioning" gets implemented

### DIFF
--- a/0001-fix-appstream.patch
+++ b/0001-fix-appstream.patch
@@ -1,7 +1,11 @@
-From 425acff1f944fa7526942a9fd2d61b74d26b0a22 Mon Sep 17 00:00:00 2001
+From d1301df2352507f662f105fe25742dab5c65d556 Mon Sep 17 00:00:00 2001
 From: Anthony Rabbito <hello@anthonyrabbito.com>
-Date: Sat, 4 Sep 2021 23:52:28 -0400
-Subject: [PATCH 1/2] Squashed commit of the following:
+Date: Fri, 10 Sep 2021 08:13:15 -0400
+Subject: [PATCH 1/2] fix: for flathub
+
+See thread for versioning - https://invent.kde.org/education/artikulate/-/merge_requests/7?diff_id=158022#5c4cdd1800d4fd59884c2bf4df4586444cbd760b_167_168
+
+Squashed following:
 
 commit b053ad7d4e88c54473b667284577f88156b04841
 Author: Anthony Rabbito <hello@anthonyrabbito.com>
@@ -40,102 +44,48 @@ Date:   Fri Sep 3 22:33:01 2021 -0400
 
 Signed-off-by: Anthony Rabbito <hello@anthonyrabbito.com>
 ---
- org.kde.artikulate.appdata.xml | 1 +
- 1 file changed, 1 insertion(+)
+ org.kde.artikulate.appdata.xml | 4 ++++
+ 1 file changed, 4 insertions(+)
 
 diff --git a/org.kde.artikulate.appdata.xml b/org.kde.artikulate.appdata.xml
-index 6403f4c..12729d4 100644
+index 6403f4c..74c7e5e 100644
 --- a/org.kde.artikulate.appdata.xml
 +++ b/org.kde.artikulate.appdata.xml
-@@ -164,4 +164,5 @@ SPDX-License-Identifier: CC0-1.0
+@@ -164,4 +164,8 @@ SPDX-License-Identifier: CC0-1.0
    <provides>
      <binary>artikulate</binary>
    </provides>
++  <releases>
++    <release version="1.0.0" date="2021-09-02"/>
++  <releases>
 +  <content_rating type="oars-1.1"/>
  </component>
 -- 
 2.32.0
 
 
-From e2e39e9b20e1e9681db639c2c931e289ac45a98a Mon Sep 17 00:00:00 2001
+From 84d3ef1124cb4d26fb677933d67b7db34f3f7442 Mon Sep 17 00:00:00 2001
 From: Anthony Rabbito <hello@anthonyrabbito.com>
-Date: Sat, 4 Sep 2021 23:53:55 -0400
-Subject: [PATCH 2/2] Squashed commit of the following:
-
-commit 0f0dfa4fb5ff9a1ad9c720205e4ef30b3226aaa0
-Author: Anthony Rabbito <hello@anthonyrabbito.com>
-Date:   Sat Sep 4 23:23:15 2021 -0400
-
-    fix: add release to appstream
-
-    Signed-off-by: Anthony Rabbito <hello@anthonyrabbito.com>
-
-commit c707748583b73334ae03d57b7762d956909e804b
-Author: Anthony Rabbito <hello@anthonyrabbito.com>
-Date:   Sat Sep 4 23:10:17 2021 -0400
-
-    fix: use non-gear versioning
-
-    Signed-off-by: Anthony Rabbito <hello@anthonyrabbito.com>
+Date: Fri, 10 Sep 2021 08:15:36 -0400
+Subject: [PATCH 2/2] fix: syntax
 
 Signed-off-by: Anthony Rabbito <hello@anthonyrabbito.com>
 ---
- CMakeLists.txt                 | 11 +++++++++--
- org.kde.artikulate.appdata.xml |  3 +++
- src/CMakeLists.txt             |  2 +-
- 3 files changed, 13 insertions(+), 3 deletions(-)
+ org.kde.artikulate.appdata.xml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 5ad049f..a3defe3 100644
---- a/CMakeLists.txt
-+++ b/CMakeLists.txt
-@@ -1,12 +1,19 @@
- # SPDX-FileCopyrightText: 2013-2016 Andreas Cord-Landwehr <cordlandwehr@kde.org>
- # SPDX-License-Identifier: BSD-2-Clause
- 
--project(artikulate)
--
- cmake_minimum_required(VERSION 3.5.0)
- set(QT_MIN_VERSION "5.11.0")
- set(KF5_MIN_VERSION "5.64.0")
- 
-+# KDE Application Version, managed by release script
-+set (RELEASE_SERVICE_VERSION_MAJOR "21")
-+set (RELEASE_SERVICE_VERSION_MINOR "11")
-+set (RELEASE_SERVICE_VERSION_MICRO "70")
-+set (RELEASE_SERVICE_COMPACT_VERSION "${RELEASE_SERVICE_VERSION_MAJOR}${RELEASE_SERVICE_VERSION_MINOR}${RELEASE_SERVICE_VERSION_MICRO}")
-+set (ARTIKULATE_VERSION "1.0.0.${RELEASE_SERVICE_COMPACT_VERSION}")
-+
-+project(artikulate VERSION ${ARTIKULATE_VERSION})
-+
- find_package(ECM ${KF5_MIN_VERSION} REQUIRED NO_MODULE)
- find_package(KF5DocTools)
- set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH} )
 diff --git a/org.kde.artikulate.appdata.xml b/org.kde.artikulate.appdata.xml
-index 12729d4..16003e5 100644
+index 74c7e5e..7bad400 100644
 --- a/org.kde.artikulate.appdata.xml
 +++ b/org.kde.artikulate.appdata.xml
-@@ -165,4 +165,7 @@ SPDX-License-Identifier: CC0-1.0
-     <binary>artikulate</binary>
+@@ -166,6 +166,6 @@ SPDX-License-Identifier: CC0-1.0
    </provides>
-   <content_rating type="oars-1.1"/>
-+  <releases>
-+    <release version="1.0.0.211170" date="2021-09-04"/>
+   <releases>
+     <release version="1.0.0" date="2021-09-02"/>
+-  <releases>
 +  </releases>
+   <content_rating type="oars-1.1"/>
  </component>
-diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index c3d6d61..7ab3718 100644
---- a/src/CMakeLists.txt
-+++ b/src/CMakeLists.txt
-@@ -1,7 +1,7 @@
- # SPDX-FileCopyrightText: 2013-2019 Andreas Cord-Landwehr <cordlandwehr@kde.org>
- # SPDX-License-Identifier: BSD-2-Clause
- 
--ecm_setup_version(1.0.0
-+ecm_setup_version(${ARTIKULATE_VERSION}
-     VARIABLE_PREFIX ARTIKULATE
-     VERSION_HEADER "${CMAKE_CURRENT_BINARY_DIR}/version.h"
-     PACKAGE_VERSION_FILE "${CMAKE_CURRENT_BINARY_DIR}/ArtikulateConfigVersion.cmake"
 -- 
 2.32.0
 


### PR DESCRIPTION
inital flatpak release will have 1.0.0 and further release picked up by KDE's script will use the non-gear versioning format like here https://invent.kde.org/graphics/okular/-/commit/5c16b25a1194e60eb960576b5f1f180258344fd0

See this thread: https://invent.kde.org/education/artikulate/-/merge_requests/7?diff_id=158022#5c4cdd1800d4fd59884c2bf4df4586444cbd760b_167_168

Signed-off-by: Anthony Rabbito <hello@anthonyrabbito.com>