### PR TITLE
Reduce the Flatpak size

### DIFF
--- a/org.kde.artikulate.json
+++ b/org.kde.artikulate.json
@@ -16,6 +16,7 @@
     "cleanup": [
         "/include",
         "/lib/cmake",
+        "/share/doc",
         "/share/kdevappwizard"
     ],
     "modules": [


### PR DESCRIPTION
The installed size reduced from 3.8 MB to 2.7 MB.

KDE apps usually open an external website for help documentation.

Therefore, it's not required to keep the /share/doc folder.